### PR TITLE
Add interactive betting to heads-up game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # ml-pokerbot
-1-1 Heads Up Poker Bot
+
+This project provides a simple heads-up Texas Hold'em implementation in Python. The
+logic uses a proper 52-card deck and includes hand evaluation for determining the
+winner. A command-line interface plays out a single hand with basic betting.
+
+## Running a Game
+
+Run the following command:
+
+```bash
+python play_heads_up.py
+```
+
+The script will walk through betting on the pre-flop, flop, turn and river rounds,
+prompting each player to bet or call in increments of 10 chips. Stacks and the
+pot are updated after each action and the winner of the pot is announced at the
+end of the hand. This implementation can serve as a starting point for
+machine-learning experiments or further game logic.

--- a/play_heads_up.py
+++ b/play_heads_up.py
@@ -1,0 +1,10 @@
+from poker.game import HeadsUpGame
+
+
+def main():
+    game = HeadsUpGame()
+    game.play_hand()
+
+
+if __name__ == "__main__":
+    main()

--- a/poker/__init__.py
+++ b/poker/__init__.py
@@ -1,0 +1,13 @@
+"""Basic heads-up Texas Hold'em engine."""
+
+from .cards import Card, Deck
+from .eval import evaluate_best
+from .game import HeadsUpGame, Player
+
+__all__ = [
+    'Card',
+    'Deck',
+    'evaluate_best',
+    'HeadsUpGame',
+    'Player',
+]

--- a/poker/cards.py
+++ b/poker/cards.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+import random
+
+SUITS = ['\u2660', '\u2665', '\u2666', '\u2663']  # Spades, Hearts, Diamonds, Clubs
+RANKS = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]  # 11=J,12=Q,13=K,14=A
+
+RANK_STR = {11: 'J', 12: 'Q', 13: 'K', 14: 'A'}
+
+@dataclass(frozen=True)
+class Card:
+    rank: int
+    suit: str
+
+    def __str__(self):
+        r = RANK_STR.get(self.rank, str(self.rank))
+        return f"{r}{self.suit}"
+
+class Deck:
+    def __init__(self):
+        self.cards = [Card(rank, suit) for suit in SUITS for rank in RANKS]
+        self.shuffle()
+
+    def shuffle(self):
+        random.shuffle(self.cards)
+
+    def draw(self, n=1):
+        assert len(self.cards) >= n, "Not enough cards to draw"
+        drawn = self.cards[:n]
+        self.cards = self.cards[n:]
+        return drawn if n > 1 else drawn[0]

--- a/poker/eval.py
+++ b/poker/eval.py
@@ -1,0 +1,76 @@
+from collections import Counter
+from itertools import combinations
+from typing import List, Tuple
+
+from .cards import Card
+
+HAND_RANKS = [
+    "High Card",
+    "One Pair",
+    "Two Pair",
+    "Three of a Kind",
+    "Straight",
+    "Flush",
+    "Full House",
+    "Four of a Kind",
+    "Straight Flush",
+]
+
+# Category index in HAND_RANKS list is used for comparison
+
+
+def _is_straight(ranks: List[int]) -> Tuple[bool, int]:
+    """Return (is_straight, high_card). ranks should be sorted ascending."""
+    if ranks == [2, 3, 4, 5, 14]:
+        return True, 5  # Wheel straight (A-2-3-4-5)
+    for i in range(4):
+        if ranks[i] + 1 != ranks[i + 1]:
+            return False, 0
+    return True, ranks[-1]
+
+
+def _rank_five(cards: List[Card]) -> Tuple:
+    ranks = sorted([c.rank for c in cards])
+    suits = [c.suit for c in cards]
+    rank_counts = Counter(ranks)
+    counts = sorted(rank_counts.values(), reverse=True)
+
+    is_flush = len(set(suits)) == 1
+    is_straight, high_straight = _is_straight(sorted(ranks))
+
+    if is_straight and is_flush:
+        return (8, high_straight)
+    if counts[0] == 4:
+        four = [r for r, c in rank_counts.items() if c == 4][0]
+        kicker = max(r for r in ranks if r != four)
+        return (7, four, kicker)
+    if counts[0] == 3 and counts[1] == 2:
+        three = [r for r, c in rank_counts.items() if c == 3][0]
+        pair = [r for r, c in rank_counts.items() if c == 2][0]
+        return (6, three, pair)
+    if is_flush:
+        return (5,) + tuple(sorted(ranks, reverse=True))
+    if is_straight:
+        return (4, high_straight)
+    if counts[0] == 3:
+        three = [r for r, c in rank_counts.items() if c == 3][0]
+        kickers = sorted([r for r in ranks if r != three], reverse=True)
+        return (3, three) + tuple(kickers)
+    if counts[0] == 2 and counts[1] == 2:
+        pairs = sorted([r for r, c in rank_counts.items() if c == 2], reverse=True)
+        kicker = [r for r, c in rank_counts.items() if c == 1][0]
+        return (2, pairs[0], pairs[1], kicker)
+    if counts[0] == 2:
+        pair = [r for r, c in rank_counts.items() if c == 2][0]
+        kickers = sorted([r for r in ranks if r != pair], reverse=True)
+        return (1, pair) + tuple(kickers)
+    return (0,) + tuple(sorted(ranks, reverse=True))
+
+
+def evaluate_best(seven: List[Card]) -> Tuple[int, Tuple]:
+    best = (-1, ())
+    for combo in combinations(seven, 5):
+        rank = _rank_five(list(combo))
+        if rank > best[1]:
+            best = (HAND_RANKS[rank[0]], rank)
+    return best

--- a/poker/game.py
+++ b/poker/game.py
@@ -1,0 +1,138 @@
+from typing import List
+
+from .cards import Deck, Card
+from .eval import evaluate_best
+
+
+class Player:
+    def __init__(self, name: str, stack: int = 100):
+        self.name = name
+        self.cards: List[Card] = []
+        self.stack = stack
+
+    def bet(self, amount: int) -> int:
+        if amount > self.stack:
+            amount = self.stack
+        self.stack -= amount
+        return amount
+
+    def reset(self):
+        self.cards = []
+
+
+class HeadsUpGame:
+    def __init__(self, player1: str = "Player 1", player2: str = "Player 2", starting_stack: int = 100):
+        self.players = [Player(player1, starting_stack), Player(player2, starting_stack)]
+        self.deck: Deck = Deck()
+        self.board: List[Card] = []
+        self.pot: int = 0
+
+    def reset(self):
+        for p in self.players:
+            p.reset()
+        self.deck = Deck()
+        self.board = []
+        self.pot = 0
+        for p in self.players:
+            p.cards.extend(self.deck.draw(2))
+
+    def deal_flop(self):
+        self.board.extend(self.deck.draw(3))
+
+    def deal_turn(self):
+        self.board.append(self.deck.draw(1))
+
+    def deal_river(self):
+        self.board.append(self.deck.draw(1))
+
+    def showdown(self):
+        evaluations = []
+        for p in self.players:
+            hand = p.cards + self.board
+            result = evaluate_best(hand)
+            evaluations.append((p, result))
+        evaluations.sort(key=lambda x: x[1][1], reverse=True)
+        best_rank = evaluations[0][1][1]
+        winners = [p for p, res in evaluations if res[1] == best_rank]
+        return winners, evaluations
+
+    # --- Betting logic ---
+    def betting_round(self, stage: str, input_fn=input) -> bool:
+        """Return True if the hand ended due to a fold."""
+        print(f"\n== {stage} Betting ==")
+        bettor, caller = self.players
+        bet = 0
+
+        action = input_fn(f"{bettor.name} bet 10? (y/n) ").strip().lower()
+        if action == 'y':
+            bet = bettor.bet(10)
+            self.pot += bet
+            print(f"{bettor.name} bets {bet}. Stack: {bettor.stack}")
+            action = input_fn(f"{caller.name} call 10? (y/n) ").strip().lower()
+            if action == 'y':
+                call = caller.bet(10)
+                self.pot += call
+                print(f"{caller.name} calls {call}. Stack: {caller.stack}")
+            else:
+                print(f"{caller.name} folds. {bettor.name} wins {self.pot}")
+                bettor.stack += self.pot
+                return True
+        else:
+            action = input_fn(f"{caller.name} bet 10? (y/n) ").strip().lower()
+            if action == 'y':
+                bet = caller.bet(10)
+                self.pot += bet
+                print(f"{caller.name} bets {bet}. Stack: {caller.stack}")
+                action = input_fn(f"{bettor.name} call 10? (y/n) ").strip().lower()
+                if action == 'y':
+                    call = bettor.bet(10)
+                    self.pot += call
+                    print(f"{bettor.name} calls {call}. Stack: {bettor.stack}")
+                else:
+                    print(f"{bettor.name} folds. {caller.name} wins {self.pot}")
+                    caller.stack += self.pot
+                    return True
+        print(f"Pot is now {self.pot}")
+        return False
+
+    def play_hand(self, input_fn=input):
+        self.reset()
+        print("\n-- Hole Cards --")
+        for p in self.players:
+            print(f"{p.name} ({p.stack}): " + ' '.join(str(c) for c in p.cards))
+
+        if self.betting_round('Pre-Flop', input_fn):
+            return
+
+        self.deal_flop()
+        print("\n-- Flop --")
+        print(' '.join(str(c) for c in self.board))
+        if self.betting_round('Flop', input_fn):
+            return
+
+        self.deal_turn()
+        print("\n-- Turn --")
+        print(' '.join(str(c) for c in self.board))
+        if self.betting_round('Turn', input_fn):
+            return
+
+        self.deal_river()
+        print("\n-- River --")
+        print(' '.join(str(c) for c in self.board))
+        if self.betting_round('River', input_fn):
+            return
+
+        winners, evals = self.showdown()
+        print("\n-- Showdown --")
+        for p, res in evals:
+            hand_name, rank = res
+            print(f"{p.name}: {hand_name} ({' '.join(str(c) for c in p.cards)})")
+        if len(winners) == 1:
+            winner = winners[0]
+            winner.stack += self.pot
+            print(f"\nWinner: {winner.name} wins {self.pot}")
+        else:
+            split = self.pot // len(winners)
+            for w in winners:
+                w.stack += split
+            print("\nIt's a tie between: " + ', '.join(p.name for p in winners))


### PR DESCRIPTION
## Summary
- allow players to have chip stacks and bet
- implement betting rounds with simple yes/no prompts
- expose `play_hand()` helper to run a full hand
- simplify CLI to run one interactive game
- document betting in README

## Testing
- `printf 'n\nn\nn\nn\nn\nn\nn\nn\n' | python play_heads_up.py | head -n 40`

------
https://chatgpt.com/codex/tasks/task_e_68504e4f179c832ca9cb42ce7fb053c6